### PR TITLE
Fix very niche issue with Knot classloader.

### DIFF
--- a/core/src/main/java/org/enginehub/piston/inject/Annotations.java
+++ b/core/src/main/java/org/enginehub/piston/inject/Annotations.java
@@ -140,7 +140,7 @@ class Annotations {
                 Method::getDefaultValue
             ));
         return (Annotation) Proxy.newProxyInstance(
-            Key.class.getClassLoader(),
+            annotationType.getClassLoader(),
             new Class[] {annotationType},
             (proxy, method, args) -> {
                 AnnoMethod call = ANNOTATION_METHODS.get(MethodKey.from(method));


### PR DESCRIPTION
When running from an IDE, module dependencies are loaded in the parent
classloader, but are not passed through the Knot classloader, so trying
to proxy this annotation fails due to Key.class being in a different
classloader than the annotation itself.