### PR TITLE
Reject empty values explicitly in parsing

### DIFF
--- a/core-ap/processor/src/test/kotlin/org/enginehub/piston/RegressionTest.kt
+++ b/core-ap/processor/src/test/kotlin/org/enginehub/piston/RegressionTest.kt
@@ -236,4 +236,15 @@ class RegressionTest {
             assertEquals("Flag [-g] has already been specified.", usageEx.message)
         }
     }
+
+    @Test
+    @DisplayName("issue #46, regarding an empty token offered to a required argument")
+    fun issue46EmptyTokenForRequiredArgument() {
+        withRegressionCommands { _, manager ->
+            val usageEx = assertThrows<UsageException> {
+                manager.execute(InjectedValueAccess.EMPTY, listOf("i10", ""))
+            }
+            assertEquals("Not enough arguments.", usageEx.message)
+        }
+    }
 }

--- a/core-ap/processor/src/test/kotlin/org/enginehub/piston/suggestion/EmptyAcceptingSuggestingConverter.kt
+++ b/core-ap/processor/src/test/kotlin/org/enginehub/piston/suggestion/EmptyAcceptingSuggestingConverter.kt
@@ -1,0 +1,46 @@
+/*
+ * Piston, a flexible command management system.
+ * Copyright (C) EngineHub <https://www.enginehub.org>
+ * Copyright (C) Piston contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.enginehub.piston.suggestion
+
+import net.kyori.text.Component
+import net.kyori.text.TextComponent
+import org.enginehub.piston.converter.ArgumentConverter
+import org.enginehub.piston.converter.ConversionResult
+import org.enginehub.piston.converter.FailedConversion
+import org.enginehub.piston.converter.SuccessfulConversion
+import org.enginehub.piston.converter.SuggestionHelper.limitByPrefix
+import org.enginehub.piston.inject.InjectedValueAccess
+
+class EmptyAcceptingSuggestingConverter(private val suggestions: List<String>) : ArgumentConverter<String> {
+    override fun convert(argument: String, context: InjectedValueAccess): ConversionResult<String> {
+        return when {
+            argument.isEmpty() || argument in suggestions -> SuccessfulConversion.fromSingle(argument)
+            else -> FailedConversion.from(IllegalArgumentException("Not a valid argument: $argument"))
+        }
+    }
+
+    override fun describeAcceptableArguments(): Component {
+        return TextComponent.of("Empty, or any of $suggestions")
+    }
+
+    override fun getSuggestions(input: String, context: InjectedValueAccess): List<String> =
+        limitByPrefix(suggestions.stream(), input)
+
+}

--- a/core-ap/processor/src/test/kotlin/org/enginehub/piston/suggestion/ManagerSuggestionTest.kt
+++ b/core-ap/processor/src/test/kotlin/org/enginehub/piston/suggestion/ManagerSuggestionTest.kt
@@ -55,6 +55,8 @@ class ManagerSuggestionTest {
                     registerConverter(Key.of(String::class.java, suggest(index + 1)),
                             SimpleSuggestingConverter(set.toList()))
                 }
+                registerConverter(Key.of(String::class.java, suggest(6)),
+                        EmptyAcceptingSuggestingConverter(suggestionMatrix[0].toList()))
 
                 register("notpermitted") { cmd ->
                     cmd.description(TextComponent.of("Command with false condition"))
@@ -210,7 +212,7 @@ class ManagerSuggestionTest {
         withSuggestionManager { manager ->
             val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY,
                     listOf("sub"))
-            assertEqualUnordered(setOf("cmd", "flags"), actualSuggestions.map { it.suggestion })
+            assertEqualUnordered(setOf("cmd", "optcmd", "optopt", "flags"), actualSuggestions.map { it.suggestion })
             assertTrue(actualSuggestions.all { it.replacedArgument == 1 }, "replacement not targeted at second argument")
         }
     }
@@ -223,6 +225,96 @@ class ManagerSuggestionTest {
                     listOf("sub", "c"))
             assertEqualUnordered(setOf("cmd"), actualSuggestions.map { it.suggestion })
             assertTrue(actualSuggestions.all { it.replacedArgument == 1 }, "replacement not targeted at second argument")
+        }
+    }
+
+    @Test
+    @DisplayName("suggests only the first argument when a command with a required-then-optional argument is selected")
+    fun suggestsRequiredOnSelected() {
+        withSuggestionManager { manager ->
+            assertAll({
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("optcmd"))
+                assertEqualUnordered(suggestionMatrix[0], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 1 }, "replacement not targeted at second argument")
+            }, {
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("sub", "optcmd"))
+                assertEqualUnordered(suggestionMatrix[0], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 2 }, "replacement not targeted at third argument")
+            })
+        }
+    }
+
+    @Test
+    @DisplayName("suggests only the required argument at a fresh slot opened by a trailing space")
+    fun suggestsRequiredOnTrailingSpace() {
+        withSuggestionManager { manager ->
+            assertAll({
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("optcmd", ""))
+                assertEqualUnordered(suggestionMatrix[0], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 1 }, "replacement not targeted at second argument")
+            }, {
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("sub", "optcmd", ""))
+                assertEqualUnordered(suggestionMatrix[0], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 2 }, "replacement not targeted at third argument")
+            })
+        }
+    }
+
+    @Test
+    @DisplayName("suggests both arguments concurrently when two optionals are in a row")
+    fun suggestsBothOptionalsConcurrently() {
+        withSuggestionManager { manager ->
+            assertAll({
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("optopt"))
+                assertEqualUnordered(suggestionMatrix[0] + suggestionMatrix[1], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 1 }, "replacement not targeted at second argument")
+            }, {
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("sub", "optopt"))
+                assertEqualUnordered(suggestionMatrix[0] + suggestionMatrix[1], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 2 }, "replacement not targeted at third argument")
+            }, {
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("optopt", ""))
+                assertEqualUnordered(suggestionMatrix[0] + suggestionMatrix[1], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 1 }, "replacement not targeted at second argument")
+            }, {
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("sub", "optopt", ""))
+                assertEqualUnordered(suggestionMatrix[0] + suggestionMatrix[1], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 2 }, "replacement not targeted at third argument")
+            })
+        }
+    }
+
+    @Test
+    @DisplayName("narrows the first argument when it is partially filled")
+    fun suggestsNarrowedFirst() {
+        withSuggestionManager { manager ->
+            assertAll({
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("optcmd", "a"))
+                assertEqualUnordered(suggestionMatrix[0].filter(byPrefix("a")), actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 1 }, "replacement not targeted at second argument")
+            }, {
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY, listOf("sub", "optcmd", "a"))
+                assertEqualUnordered(suggestionMatrix[0].filter(byPrefix("a")), actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 2 }, "replacement not targeted at third argument")
+            })
+        }
+    }
+
+    @Test
+    @DisplayName("suggests the optional second argument once the first is filled")
+    fun suggestsSecondWhenFirstFilled() {
+        withSuggestionManager { manager ->
+            assertAll({
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY,
+                        listOf("optcmd", suggestionMatrix[0].first()))
+                assertEqualUnordered(suggestionMatrix[1], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 2 }, "replacement not targeted at third argument")
+            }, {
+                val actualSuggestions = manager.getSuggestions(InjectedValueAccess.EMPTY,
+                        listOf("optcmd", suggestionMatrix[0].first(), ""))
+                assertEqualUnordered(suggestionMatrix[1], actualSuggestions.map { it.suggestion })
+                assertTrue(actualSuggestions.all { it.replacedArgument == 2 }, "replacement not targeted at third argument")
+            })
         }
     }
 

--- a/core-ap/processor/src/test/kotlin/org/enginehub/piston/suggestion/SuggestingCommand.kt
+++ b/core-ap/processor/src/test/kotlin/org/enginehub/piston/suggestion/SuggestingCommand.kt
@@ -33,6 +33,14 @@ interface SuggestingCommand {
             @[Arg(desc = "Required third argument") Suggest(3)] third: String,
             @[Arg(desc = "Required fourth argument") Suggest(4)] fourth: String)
 
+    @Command(name = "optcmd", desc = "required argument followed by an optional argument")
+    fun optcmd(@[Arg(desc = "Required first argument") Suggest(6)] first: String,
+               @[Arg(desc = "Optional second argument", def = [""]) Suggest(2)] second: String)
+
+    @Command(name = "optopt", desc = "two optional arguments in a row")
+    fun optopt(@[Arg(desc = "Optional first argument", def = [""]) Suggest(1)] first: String,
+               @[Arg(desc = "Optional second argument", def = [""]) Suggest(2)] second: String)
+
     @Command(name = "flags", desc = "flag test command")
     fun flags(@[Switch(name = '1', desc = "First flag")] first: Boolean,
               @[Switch(name = '2', desc = "Second flag")] second: Boolean,

--- a/default-impl/src/main/java/org/enginehub/piston/impl/CommandParser.java
+++ b/default-impl/src/main/java/org/enginehub/piston/impl/CommandParser.java
@@ -177,6 +177,14 @@ class CommandParser {
         return usageException(TextComponent.of("Too many arguments."));
     }
 
+    private UsageException rejectedArgumentException(ArgAcceptingCommandPart nextArg, String token) {
+        if (token.isEmpty()) {
+            // an empty token is an absent value, not a value that failed conversion
+            return notEnoughArgumentsException();
+        }
+        return conversionFailedException(nextArg, token);
+    }
+
     private ConversionFailedException conversionFailedException(ArgAcceptingCommandPart nextArg, String token) {
         // TODO: Make this print all converters
         ArgumentConverter<?> converter = nextArg.getTypes().stream()
@@ -343,7 +351,7 @@ class CommandParser {
                 // Hit end of parts, this cannot be parsed
                 if (lastFailedOptional != null) {
                     // fail on type-conversion to this instead
-                    throw conversionFailedException(lastFailedOptional, token);
+                    throw rejectedArgumentException(lastFailedOptional, token);
                 }
                 throw tooManyArgumentsException();
             }
@@ -430,7 +438,7 @@ class CommandParser {
                 // good, we can just satisfy it
                 AcceptInfo acceptInfo = getAcceptInfoFromTypeParsers(argPart, token);
                 if (!acceptInfo.isAccepted()) {
-                    throw conversionFailedException(argPart, token);
+                    throw rejectedArgumentException(argPart, token);
                 }
                 details.remainingRequiredParts--;
                 addValueFull(nextArg, v -> v.values(consumeArguments(
@@ -508,6 +516,9 @@ class CommandParser {
         if (types.isEmpty()) {
             return AcceptInfo.ACCEPTED_EXACT;
         }
+        if (next.isEmpty()) {
+            return AcceptInfo.REJECTED;
+        }
 
         boolean acceptedInexact = false;
         for (Key<?> type : types) {
@@ -555,7 +566,7 @@ class CommandParser {
                 String nextToken = nextArgument();
                 AcceptInfo acceptInfo = getAcceptInfoFromTypeParsers(argPart, nextToken);
                 if (!acceptInfo.isAccepted()) {
-                    throw conversionFailedException(argPart, nextToken);
+                    throw rejectedArgumentException(argPart, nextToken);
                 }
                 addValueFull(flag, v -> v.value(nextToken));
                 bind(flag, acceptInfo == AcceptInfo.ACCEPTED_EXACT);


### PR DESCRIPTION
This allows suggestions to trigger on them properly, ensuring that converters don't ever see an empty string as input (and potentially accept it). Fixes #46